### PR TITLE
ルートメタフィールド

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -53,6 +53,7 @@ const routes = [
     path: '/settings',
     name: 'UserSettings',
     component: () => import(/* webpackChunkName: "about" */ '../views/NestedNamed/UserSettings.vue'),
+    meta: { requiresAuth: true },
     children: [
       {
         path: '',
@@ -93,7 +94,12 @@ const router = createRouter({
 // https://router.vuejs.org/ja/api/#%E3%83%A1%E3%82%BD%E3%83%83%E3%83%88%E3%82%99
 router.beforeEach((to, from, next) => { // eslint-disable-line
   console.log("global:beforeEach")
-  next()
+  if (to.matched.some(record => record.meta.requiresAuth)) {
+    console.log("requiresAuth is true.")
+    next()
+  } else {
+    next()
+  }
 })
 
 router.beforeResolve((to, from, next) => { // eslint-disable-line

--- a/src/views/Users.vue
+++ b/src/views/Users.vue
@@ -24,7 +24,7 @@ export default {
   name: "Users",
   props: {
     id: {
-      type: Number,
+      type: String,
     },
   },
   beforeRouteEnter(to, from, next) { // eslint-disable-line


### PR DESCRIPTION
## 対応内容
- [ルートメタフィールド](https://router.vuejs.org/ja/guide/advanced/meta.html)

## 備考
Nested の場合、to.matched は、親、子供の両方の component が含まれている.  
そのため、両方が一致するにしたい場合は、```to.matched.every``` でいけるが使い道はなさそう.
```javascript
router.beforeEach((to, from, next) => { // eslint-disable-line
  console.log("global:beforeEach")
  if (to.matched.some(record => record.meta.requiresAuth)) {
    console.log("requiresAuth is true.")
    next()
  } else {
    next()
  }
})
```

## ハマりポイント
