### PR TITLE
トランジション

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -4,10 +4,14 @@
     <router-link to="/about">About</router-link> |
     <router-link to="/users/1">User:1</router-link> |
     <router-link to="/users/2">User:2</router-link> |
-    <router-link to="/settings">UserSettings</router-link> | 
+    <router-link to="/settings">UserSettings</router-link> |
     <router-link to="/redirect/users/1">Redirect User</router-link>
   </div>
-  <router-view />
+  <router-view v-slot="{ Component }">
+    <transition name="fade" mode="out-in">
+      <component :is="Component" />
+    </transition>
+  </router-view>
 </template>
 
 <style>

--- a/src/views/Users.vue
+++ b/src/views/Users.vue
@@ -3,19 +3,15 @@
 <template>
   <div class="users">
     <div id="nav">
-      <router-link :to="{ name: 'UsersTop', params: { id: id } }"
-        >Top</router-link
-      >
-      |
-      <router-link :to="{ name: 'Profile', params: { id: id } }"
-        >Profile</router-link
-      >
-      |
-      <router-link :to="{ name: 'Posts', params: { id: id } }"
-        >Posts</router-link
-      >
+      <router-link :to="{ name: 'UsersTop', params: { id: id } }">Top</router-link> |
+      <router-link :to="{ name: 'Profile', params: { id: id } }">Profile</router-link> | 
+      <router-link :to="{ name: 'Posts', params: { id: id } }">Posts</router-link>
     </div>
-    <router-view />
+    <router-view class="child-view" v-slot="{ Component }">
+      <transition :name="transitionName">
+        <component :is="Component" />
+      </transition>
+    </router-view>
   </div>
 </template>
 
@@ -26,6 +22,11 @@ export default {
     id: {
       type: String,
     },
+  },
+  data() {
+    return {
+      transitionName: 'slide-left'
+    }
   },
   beforeRouteEnter(to, from, next) { // eslint-disable-line
     // このコンポーネントを描画するルートが確立する前に呼ばれます。
@@ -41,6 +42,9 @@ export default {
     // 同じ `Foo` コンポーネントインスタンスが再利用され、そのときにこのフックが呼び出されます。
     // `this` でコンポーネントインスタンスにアクセスできます。
     console.log("component:beforeRouteUpdate");
+    const toDepth = to.path.split('/').length
+    const fromDepth = from.path.split('/').length
+    this.transitionName = toDepth < fromDepth ? 'slide-right' : 'slide-left'
     next();
   },
   beforeRouteLeave(to, from, next) { // eslint-disable-line
@@ -53,3 +57,27 @@ export default {
   setup() {},
 };
 </script>
+
+<!-- https://github.com/vuejs/vue-router/blob/dev/examples/transitions/index.html -->
+<style>
+.fade-enter-active, .fade-leave-active {
+  transition: opacity .75s ease;
+}
+.fade-enter, .fade-leave-active {
+  opacity: 0;
+}
+.child-view {
+  position: absolute;
+  transition: all .75s cubic-bezier(.55,0,.1,1);
+}
+.slide-left-enter, .slide-right-leave-active {
+  opacity: 0;
+  -webkit-transform: translate(30px, 0);
+  transform: translate(30px, 0);
+}
+.slide-left-leave-active, .slide-right-enter {
+  opacity: 0;
+  -webkit-transform: translate(-30px, 0);
+  transform: translate(-30px, 0);
+}
+</style>


### PR DESCRIPTION
## 対応内容
- [トランジション](https://router.vuejs.org/ja/guide/advanced/transitions.html)

## 参考リンク
- [Enter/Leave とトランジション一覧](https://jp.vuejs.org/v2/guide/transitions.html#%E3%83%88%E3%83%A9%E3%83%B3%E3%82%B8%E3%82%B7%E3%83%A7%E3%83%B3%E3%82%AF%E3%83%A9%E3%82%B9)
- https://github.com/vuejs/vue-router/blob/dev/examples/transitions/app.js

## ハマりポイント
warn が発生する.
```
[Vue Router warn]: <router-view> can no longer be used directly inside <transition> or <keep-alive>.
Use slot props instead:
```

下記に修正すれば問題なし.
```javascript
<router-view v-slot="{ Component }">
  <transition>
    <component :is="Component" />
  </transition>
</router-view>
```
